### PR TITLE
Migrate MLflow Registery (on dagshub)

### DIFF
--- a/src/scripts/util/log_late_manually_in_dagshub.py
+++ b/src/scripts/util/log_late_manually_in_dagshub.py
@@ -1,0 +1,58 @@
+import os
+import dagshub
+import mlflow
+from dotenv import load_dotenv
+from transformers import VisionEncoderDecoderModel
+from transformers import Seq2SeqTrainingArguments
+
+def log_manually_single_run_in_dagshub(experiment_name, dir, run_name, args=None):
+    load_dotenv()
+    dagshub.init(repo_owner=os.environ["DAGSHUB_MLFLOW_TRACKING_USERNAME"], repo_name=os.environ["DAGSHUB_REPOSITORY"], mlflow=True)
+
+    print(mlflow.get_tracking_uri())
+
+    # Setze das MLflow-Experiment
+    mlflow.set_experiment(experiment_name)
+
+    with mlflow.start_run(run_name=run_name):
+        # Modell laden
+        model = VisionEncoderDecoderModel.from_pretrained(dir)
+
+        # Modell loggen
+        mlflow.pytorch.log_model(model, artifact_path="model")
+
+        # Logge die Checkpoint-Nummer
+        step = int(dir.split("-")[-1])
+        mlflow.log_param("checkpoint", dir)
+        mlflow.log_param("step", step)
+
+        # TrainingArguments loggen
+        for arg_name, value in vars(args).items():
+            # Einige Objekte (wie Logging dir) sind nicht JSON-kompatibel → überspringen
+            try:
+                mlflow.log_param(arg_name, value)
+            except:
+                continue
+
+        # Optional: Tags oder weitere Metadaten
+        mlflow.set_tag("logged_late", "true")
+
+if __name__ == "__main__":
+    experiment_name = "TrOCR_Nachträgliche_Checkpoints"
+    checkpoint_dir = "./training-results/checkpoint-4000"
+    run_name = "checkpoint-4000"
+
+    training_args = Seq2SeqTrainingArguments(
+        predict_with_generate=True,
+        eval_strategy="steps",
+        per_device_train_batch_size=8,
+        per_device_eval_batch_size=8,
+        fp16=True,
+        output_dir="./results",
+        logging_steps=2,
+        save_steps=1000,
+        eval_steps=100,
+        disable_tqdm=False,
+        report_to="none",
+    )
+    log_manually_single_run_in_dagshub(experiment_name,checkpoint_dir, run_name, args=training_args)


### PR DESCRIPTION
# Done
Migrate the latest TrOCR model from the MLflow Registery (on dagshub) from [chess-scoresheet-digitalizer](https://dagshub.com/benjaminkost/chess-scoresheet-digitalizer) to the Registery connected to the [chess-scoresheet-digitization-training](https://dagshub.com/benjaminkost/chess-scoresheet-digitization-training)

# Test
- Open https://dagshub.com/benjaminkost/chess-scoresheet-digitization-training.mlflow
- Check if the latest fined TrOCR model (that was trained on [Kaggle](https://www.kaggle.com/code/benkostka/train-trocr-on-handwritten-chess-notation)) is registered